### PR TITLE
Fixed minio keys in compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,7 @@ services:
       - "9000:9000"
     environment:
       MINIO_ACCESS_KEY: minio
-      MINIO_SECRET_KEY: replaceme
+      MINIO_SECRET_KEY: minio123
     command: server ~/Downloads/minio
 
   # FDNS Object Microservice


### PR DESCRIPTION
The FDNS Storage microservice consistently returns HTTP 400 response codes, but only when accessed after being started via `make docker-start` on the FDNS Gateway microservice. This issue does not occur when starting FDNS Storage by itself.

The reason is that the keys for Minio are inconsistent in Gateway's `docker-compose.yml` file: Under `minio` the key is `replaceme` but under `fdns-ms-storage`, the key is `minio123`. 

I've changed the keys to `minio123`. That key is also used in the `fdns-ms-storage` `docker-compose.yml` file.