### PR TITLE
Updating the CI/CD script on GitLab

### DIFF
--- a/.gitlab-aws.yml
+++ b/.gitlab-aws.yml
@@ -1,12 +1,3 @@
-image: docker:stable
-
-services:
-  - docker:dind
-
-variables:
-  DOCKER_DRIVER: overlay2
-  DOCKER_HOST: tcp://localhost:2375
-
 stages:
   - build
   - deploy
@@ -16,9 +7,6 @@ build:
   stage: build
   only:
     - master
-  before_script:
-    - apk add --no-cache curl jq python py-pip make
-    - pip install awscli docker-compose
   script:
     - make docker-build
     - docker tag $CI_PROJECT_NAME $DOCKER_ORG/$CI_PROJECT_NAME:latest
@@ -32,12 +20,8 @@ build:
 
 deploy:
   stage: deploy
-  image: roffe/kubectl
   only:
     - master
-  before_script:
-    - mkdir -p $HOME/.kube
-    - echo -n $KUBE_CONFIG | base64 -d > $HOME/.kube/config
   script:
     - kubectl set image deployment/$CI_PROJECT_NAME $CI_PROJECT_NAME=$DOCKER_ORG/$CI_PROJECT_NAME:latest
 


### PR DESCRIPTION
This pull request proposes a change to using a gitlab-runner shell executor. Future improvements could be made to have multiple versions for different gitlab executors.

This also adds `docker-compose pull` as `docker-compose up` does not get the latest if the image already exists.